### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -106,7 +106,7 @@ requests can be made using GitHub's `issues system`_.
    :target: https://travis-ci.org/shendo/netsink
    :alt: Current build status
 
-.. |pypi_version| image:: https://pypip.in/v/netsink/badge.png
+.. |pypi_version| image:: https://img.shields.io/pypi/v/netsink.svg
    :target: https://pypi.python.org/pypi/netsink
    :alt: Latest PyPI version
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20netsink))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `netsink`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.